### PR TITLE
Use net/http instead of httparty

### DIFF
--- a/lib/postcodeapi.rb
+++ b/lib/postcodeapi.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 
-require 'httparty'
 require 'hashie'
+require 'json'
 
 require "postcodeapi/version"
 require "postcodeapi/api"

--- a/lib/postcodeapi/api.rb
+++ b/lib/postcodeapi/api.rb
@@ -1,19 +1,23 @@
 module Postcode
   # You're required to sign up for an api key at http://postcodeapi.nu
   class API
-    include HTTParty
-
-    base_uri "http://api.postcodeapi.nu"
+    BASE_URI = "http://api.postcodeapi.nu"
 
     def initialize(api_key)
       @api_key = api_key
     end
 
     def postcode(postcode, house_number = nil, options = {})
-      options.merge!(:headers => { "Api-Key" => @api_key})
-      query = [postcode, house_number].compact.join("/")
-      response = self.class.get("/#{query}", options)
-      Hashie::Mash.new(response.parsed_response)
+      uri = URI.parse([BASE_URI, postcode, house_number].compact.join('/'))
+
+      req = Net::HTTP::Get.new(uri.path)
+      req.add_field('Api-Key', @api_key)
+
+      res = Net::HTTP.new(uri.host, uri.port).start do |http|
+        http.request(req)
+      end
+
+      Hashie::Mash.new(JSON.parse(res.body))
     end
   end
 end

--- a/postcodeapi.gemspec
+++ b/postcodeapi.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'httparty', '~> 0.10.2'
   gem.add_dependency 'hashie', '~> 1.2.0'
 
   gem.add_development_dependency 'rake', '~> 10.0.3'


### PR DESCRIPTION
I know it's a matter of preference, but I found it unnecessary to pull httparty into my application for just this Gem since there seems no real benefit to it. So I replaced it with net/http and the internal JSON module of Ruby >= 1.9.2.
