### PR TITLE
Also allowing newer versions of hashie

### DIFF
--- a/postcodeapi.gemspec
+++ b/postcodeapi.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'hashie', '~> 1.2.0'
+  gem.add_dependency 'hashie', '>= 1.2.0'
 
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'rspec', '~> 2.12.0'


### PR DESCRIPTION
I had problems integrating this gem due to incompatibility of the hashie version. I changed the requirements, and it still works like this. 
