### PR TITLE
Sanitize zipcode input

### DIFF
--- a/lib/postcodeapi/api.rb
+++ b/lib/postcodeapi/api.rb
@@ -8,6 +8,7 @@ module Postcode
     end
 
     def postcode(postcode, house_number = nil, options = {})
+      postcode = sanitize(postcode)
       uri = URI.parse([BASE_URI, postcode, house_number].compact.join('/'))
 
       req = Net::HTTP::Get.new(uri.path)
@@ -18,6 +19,10 @@ module Postcode
       end
 
       Hashie::Mash.new(JSON.parse(res.body))
+    end
+
+    def sanitize(postcode)
+      postcode.gsub(/\s+/, '').upcase
     end
   end
 end

--- a/spec/postcodeapi/api_spec.rb
+++ b/spec/postcodeapi/api_spec.rb
@@ -40,6 +40,13 @@ describe Postcode::API do
         result.resource.latitude.should eq(51.9401)
         result.resource.longitude.should eq(5.61531)
       end
+
+      it 'sanitizes input before lookup' do
+        result = api.postcode('5041 eb')
+
+        result.success.should be_true
+        result.resource.postcode.should eq("5041EB")
+      end
     end
 
     context "with postcode and house number" do


### PR DESCRIPTION
Clean up input zipcodes so they are sent correctly to the PostcodeAPI endpoint.

E.g. `5694 aj` should be sanitized to `5694AJ`